### PR TITLE
fix glossary table

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,6 @@ The following table provides definitions to the terms to be frequently mentioned
 | Indoor Cam | Short for SwitchBot Indoor Cam Model No. W1301200                  |
 | Pan/Tilt Cam | Short for SwitchBot Pan/Tilt Cam Model No. W1801200                  |
 | Pan/Tilt Cam 2K | Short for SwitchBot Pan/Tilt Cam 2K Model No. W3101100                  |
-
 | Cloud Service                | An SwitchBot app feature that 1. enables SwitchBot products to be discovered and communicated with third-party services voice control services, 2. allows users to create customized smart scenes and Android widgets. For BLE-based devices such as Bot and Curtain, you MUST first add a Hub/Hub Mini/Hub Plus and then enable Cloud Service on the Settings page in order to make use of the web API! |
 
 


### PR DESCRIPTION
## :recycle: Current situation

On GitHub UI, the glossary table in the README is broken

## :bulb: Proposed solution

Remove a line between Pan/Tilt Cam 2K and Cloud Service

## :gear: Release Notes

Fix glossary table

### Testing

Checked on GitHub UI for my fork of the repository

### Reviewer Nudging

See the table in main branch and this branch
