### PR TITLE
Fix python3 example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ apiHeader['Authorization']=token
 apiHeader['Content-Type']='application/json'
 apiHeader['charset']='utf8'
 apiHeader['t']=str(t)
-apiHeader['sign']=sign
+apiHeader['sign']=str(sign, 'utf-8')
 apiHeader['nonce']=str(nonce)
 
 ```


### PR DESCRIPTION
'sign' should be string as described. But on non-utf8-systems (MS Windows) the auto-convert do wrong and an AuthException is raised by the API. So it should be explicitly done bevore trying to connect the API

It took me an hour to find the problem