### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,6 +1381,7 @@ Send control commands to physical devices and virtual infrared remote devices.
 | Curtain    | command     | setPosition | index0,mode0,position0<br />e.g. `0,ff,80` | mode: 0 (Performance Mode), 1 (Silent Mode), ff (default mode) <br />position: 0~100 (0 means open, 100 means closed) |
 | Curtain    | command     | turnOff     | default                                    | equivalent to set position to 100                            |
 | Curtain    | command     | turnOn      | default                                    | equivalent to set position to 0                              |
+| Curtain    | command     | pause       | default                                    | set to PAUSE state                                           |
 
 ##### Lock
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |


### PR DESCRIPTION
I added a line in the curtain section of the documentation to add the pause command. This command is inside the API itself, but it is undocumented. I imagine this is unintentional, likely an over sight, and should be fixed, because it does work. I tested in v1.1 of the API no issue with command:pause.

## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
