### PR TITLE
Correct errors in the newly added device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2213,7 +2213,7 @@ Send control commands to physical devices and virtual infrared remote devices.
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | pause       | default                                                      | pause cleaning                                               |
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | dock        | default                                                      | return to charging dock                                      |
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | setVolume   | `{0-100}`                                                    | set the robot volume                                         |
-| Robot Vacuum Cleaner K10+ Pro Combo | command     | changeParam | {"fanLevel": fan_level_int, "waterLevel": water_level_int, "times": clean_cycle_int} | change clean parameters. `fan_level_int`, the vacuum level, `1-4`; `water_level_int`, the mop moisture level, `1-2`; `times`, the number of cycles, `1-2639999`, in theory. |
+| Robot Vacuum Cleaner K10+ Pro Combo | command     | changeParam | {"fanLevel": fan_level_int, "times": clean_cycle_int} | change clean parameters. `fan_level_int`, the vacuum level, `1-4`; `times`, the number of cycles, `1-2639999`, in theory. |
 
 
 ##### Floor Cleaning Robot S10

--- a/README.md
+++ b/README.md
@@ -4068,8 +4068,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4098,8 +4097,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4128,8 +4126,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4158,8 +4155,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 


### PR DESCRIPTION
These are based on assumptions about product features, as I do not have detailed knowledge of the actual API or Webhook specifications.
The following changes have been made.

* `changeParam` command for K10+ Pro Combo
  * Remove the `waterLevel` property.
  It seems to have been left unchanged when copied from the S10.

* Webhook payload for 4 Air Purifier models
  * Remove the `drying` property.
  * Modify the description of the `mode` property to match the StatusAPI.
  These also seem to have been left unchanged when copied from the Evaporative Humidifier (Auto-refill).
 Or, does the StatusAPI have a range of 1 to 4, while the Webhook has a range of 1 to 8 (including fan levels)?
