### PR TITLE
Add Go/golang example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,14 +607,12 @@ import (
     "net/http"
     "strings"
     "time"
-
-    "github.com/google/uuid"
 )
 
 func main() {
     token := "XXXXXXXXXXXXXXXXXXX"      // copy and paste from the SwitchBot app V6.14 or later
     secret := "YYYYYYYYYYY"             // copy and paste from the SwitchBot app V6.14 or later
-    nonce := uuid.NewString()           // generate random UUID v4
+    nonce := UUID()                     // generate random UUID v4
     timestamp := time.Now().UnixMilli() // 13-digit milliseconds Unix timestamp
 
     data := fmt.Sprintf("%s%d%s", token, timestamp, nonce)
@@ -652,6 +650,21 @@ func main() {
     }
 
     fmt.Println(string(body)) // Response in JSON format
+}
+
+// UUID returns an RFC 4122/9562–compliant random UUIDv4 string.
+func UUID() string {
+    var uuid [16]byte                 // 128-bit long array
+    rand.Read(uuid[:])                // Use cryptographically secure random source
+    uuid[6] = (uuid[6] & 0x0F) | 0x40 // Version (UUIDv4 = 0100)
+    uuid[8] = (uuid[8] & 0x3F) | 0x80 // Variant (RFC9562 / RFC4122 = 10xxxxxx)
+
+    return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+        uuid[0:4],  // 4 bytes
+        uuid[4:6],  // 2 bytes
+        uuid[6:8],  // 2 bytes (version included)
+        uuid[8:10], // 2 bytes (variant included)
+        uuid[10:])  // 6 bytes
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     + [C# example code](#c-example-code)
     + [Java 11+ example code](#java-11-example-code)
     + [PHP example code](#php-example-code)
+    + [Swift example code](#swift-example-code)
     + [Go example code](#go-example-code)
 - [Glossary](#glossary)
 - [API Usage](#api-usage)


### PR DESCRIPTION
## :recycle: Current situation

- There is no Go (golang) example in the README.md 😢 
- Swift example code is missing the link in the index of README.md

### Testing

- Tested on:
  - go version go1.24.1 darwin/amd64
  - go version go1.24.1 linux/amd64 | golang:alpine @ Docker
- This code should work in Go v17+.

### Reviewer Nudging

#### Local run

If Go (golang, v1.17+) is installed locally:

1. Create a `main.go` file in the working directory
1. Copy & paste the example code of Go to `main.go`
1. Replace the `token` and `secret` variable in the `main.go`
1. Initialize the modules and build/run the code:

  ```shellsession
  $ go mod init example/switchbot && go mod tidy
  **snip**
  
  $ go run main.go
  **snip**
  ```

#### Docker run

Using docker may be useful if Go/golang is not installed locally:

1. Create a `main.go` file in the working directory
1. Copy & paste the example code of Go to `main.go`
1. Replace the `token` and `secret` variable in the `main.go`
1. Pull the latest Go image of Docker
    ```shellsession
    $ docker pull golang:alpine
    ```
1. Mount the source code and instantiate a container and run:
    ```slesllsession
    $ docker run --rm -it -v "$(pwd)":/app -w /app golang:alpine /bin/sh
    /app # go mod init example/switchbot && go mod tidy
    **snip**

    /app # go run main.go
    **snip**
    ```