### PR TITLE
Correct errors in the newly added device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2228,6 +2228,18 @@ The `body` object contains the following properties,
 | lockState              | String     | determines if locked or not, *jammed*, *unlock* or *lock* |
 | calibrate     | Boolean      | determines if the open and the closed positions have been properly calibrated or not |
 
+##### Lock Ultra
+| Key                | Value Type      | Description                                                  |
+| ------------------ | --------------- | ------------------------------------------------------------ |
+| deviceId           | String          | device ID                                                    |
+| deviceType         | String          | device type. *Lock Ultra*                                |
+| hubDeviceId        | String          | device's parent Hub ID                                       |
+| battery              | Integer | the current battery level, 0-100 |
+| version              | String     | the current firmware version, e.g. V4.2 |
+| lockState              | String     | determines if locked or not, *jammed*, *unlock* or *lock* |
+| doorState              | String     | determines if the door is closed or not, *open* or *close* |
+| calibrate          | Boolean         | determines if Lock has been calibrated or not |
+
 ##### Video Doorbell
 
 | Key             | Value Type | Description                                               |

--- a/README.md
+++ b/README.md
@@ -5014,14 +5014,13 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
     "eventType": "changeReport",
     "eventVersion": "1",
     "context": {
-        "deviceType": "Robot Vacuum Cleaner K10+ Pro Combo",
+        "deviceType": "Robot Vacuum Cleaner K20+ Pro",
         "deviceMac": DEVICE_MAC_ADDR,
         "workingStatus"："StandBy",
         //StandBy,Clearing,Paused,GotoChargeBase,Charging,ChargeDone,Dormant,InTrouble,InRemoteControl,InDustCollecting
         "onlineStatus": "online",//online,offline
         "battery": 100,// 0-100
-        "waterBaseBattery": 100,
-    "taskType": "explore", // standBy,explore,cleanAll,cleanArea,cleanRoom,deepWashing,backToCharge,drying,collectDust,remoteControl,cleanWithExplorer
+        "taskType": "explore", // standBy,explore,cleanAll,cleanArea,cleanRoom,deepWashing,backToCharge,drying,collectDust,remoteControl,cleanWithExplorer
         "timeOfSample": 123456789
     }
 }

--- a/README.md
+++ b/README.md
@@ -2607,7 +2607,7 @@ The following table describes the parameter object for `deleteKey`,
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | pause       | default                                                      | pause cleaning                                               |
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | dock        | default                                                      | return to charging dock                                      |
 | Robot Vacuum Cleaner K10+ Pro Combo | command     | setVolume   | `{0-100}`                                                    | set the robot volume                                         |
-| Robot Vacuum Cleaner K10+ Pro Combo | command     | changeParam | {"fanLevel": fan_level_int, "waterLevel": water_level_int, "times": clean_cycle_int} | change clean parameters. `fan_level_int`, the vacuum level, `1-4`; `water_level_int`, the mop moisture level, `1-2`; `times`, the number of cycles, `1-2639999`, in theory. |
+| Robot Vacuum Cleaner K10+ Pro Combo | command     | changeParam | {"fanLevel": fan_level_int, "times": clean_cycle_int} | change clean parameters. `fan_level_int`, the vacuum level, `1-4`; `times`, the number of cycles, `1-2639999`, in theory. |
 
 
 ##### Floor Cleaning Robot S10

--- a/README.md
+++ b/README.md
@@ -2098,10 +2098,10 @@ The `body` object contains the following properties,
 | hubDeviceId | String     | Hub ID, equivalent to device ID |
 | version     | String     | the current firmware version, e.g. V4.2 |
 | temperature | Float      | temperature in celsius                  |
-| lightLevel | Integer      | the level of illuminance of the ambience light, 1~10 |
+| lightLevel  | Integer    | the level of illuminance of the ambience light, 1~10 |
 | humidity    | Integer    | humidity percentage                     |
-| moveDetected           | Boolean    | determines if motion is detected |
-| online  | String     | the connection status of the device. *online* or *offline* |
+| moveDetected | Boolean   | determines if motion is detected |
+| onlineStatus | String    | the connection status of the device. *online* or *offline* |
 
 ##### Battery Circulator Fan
 | Key                 | Value Type      | Description                                                  |

--- a/README.md
+++ b/README.md
@@ -2145,6 +2145,7 @@ The `body` object contains the following properties,
 | power           | Float      | the current power, measured in Watts                      |
 | usedElectricity | Integer    | daily power consumption, measured in watt-minutes         |
 | electricCurrent | Integer    | the electrical current measured in mA                     |
+| hubDeviceId     | String     | Hub ID, equivalent to device ID                           |
 
 ##### Relay Switch 1
 
@@ -2154,6 +2155,7 @@ The `body` object contains the following properties,
 | deviceType      | String     | device type. *Relay Switch 1*                             |
 | switchStatus    | Integer    | the current switch state. `0`, off; `1`, on               |
 | version         | String     | the current BLE and Wi-Fi firmware version, e.g. V3.1-6.3 |
+| hubDeviceId     | String     | Hub ID, equivalent to device ID                           |
 
 ##### Relay Switch 2PM
 
@@ -2173,6 +2175,7 @@ The `body` object contains the following properties,
 | switch2UsedElectricity | Integer    | switch2 daily power consumption, measured in watt-minutes         |
 | switch1ElectricCurrent | Integer    | the switch1 electrical current measured in mA                     |
 | switch2ElectricCurrent | Integer    | the switch2 electrical current measured in mA                     |
+| hubDeviceId     | String     | Hub ID, equivalent to device ID                           |
 
 
 ##### Garage Door Opener

--- a/README.md
+++ b/README.md
@@ -2164,18 +2164,15 @@ The `body` object contains the following properties,
 | online    | Boolean     | the connection status of the device. *true* or *false* |
 | switch1Status    | Integer    | the current switch1 state. `0`, off; `1`, on               |
 | switch2Status    | Integer    | the current switch2 state. `0`, off; `1`, on               |
-| switch1voltage         | Integer    | the switch1 current voltage, measured in Volt                     |
-| switch2voltage         | Integer    | the switch2 current voltage, measured in Volt                     |
+| switch1Voltage         | Float    | the switch1 current voltage, measured in Volt                     |
+| switch2Voltage         | Float    | the switch2 current voltage, measured in Volt                     |
 | version         | String     | the current BLE and Wi-Fi firmware version, e.g. V3.1-6.3 |
-| switch1power           | Integer    | the switch1 current power, measured in Watts                      |
-| switch2power           | Integer    | the switch2 current power, measured in Watts                      |
-| switch1usedElectricity | Integer    | switch1 daily power consumption, measured in watt-minutes         |
-| switch2usedElectricity | Integer    | switch2 daily power consumption, measured in watt-minutes         |
-| switch1electricCurrent | Integer    | the switch1 electrical current measured in mA                     |
-| switch2electricCurrent | Integer    | the switch2 electrical current measured in mA                     |
-| calibrate     | Boolean      | determines if the open and the closed positions have been properly calibrated or not |
-| position      | Integer     | the current position, 0-100                               |
-| isStuck       | String       | determine if the roller blind is stuck                               |
+| switch1Power           | Float    | the switch1 current power, measured in Watts                      |
+| switch2Power           | Float    | the switch2 current power, measured in Watts                      |
+| switch1UsedElectricity | Integer    | switch1 daily power consumption, measured in watt-minutes         |
+| switch2UsedElectricity | Integer    | switch2 daily power consumption, measured in watt-minutes         |
+| switch1ElectricCurrent | Integer    | the switch1 electrical current measured in mA                     |
+| switch2ElectricCurrent | Integer    | the switch2 electrical current measured in mA                     |
 
 
 ##### Garage Door Opener

--- a/README.md
+++ b/README.md
@@ -4910,7 +4910,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
     "eventType": "changeReport",
     "eventVersion": "1",
     "context": {
-        "deviceType": "WoKeypadTouch",
+        "deviceType": "WoKeypadVision",
         "deviceMac": DEVICE_MAC_ADDR,
         "eventName": "createKey",
         "commandId": "CMD-1663558451952-01",
@@ -4926,7 +4926,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
     "eventType": "changeReport",
     "eventVersion": "1",
     "context": {
-        "deviceType": "WoKeypadTouch",
+        "deviceType": "WoKeypadVision",
         "deviceMac": DEVICE_MAC_ADDR,
         "eventName": "deleteKey ",
         "commandId": "CMD-1663558451952-01",

--- a/README.md
+++ b/README.md
@@ -1440,7 +1440,7 @@ The `deviceList` array contains a list of objects with the following key-value a
 | ------------------ | ---------- | ------------------------------------------------------------ |
 | deviceId           | String     | device ID                                                    |
 | deviceName         | String     | device name                                                  |
-| deviceType         | String     | device type. *LED Strip Light 3*                                   |
+| deviceType         | String     | device type. *Strip Light 3*                                   |
 | enableCloudService | Boolean    | determines if Cloud Service is enabled or not for the current device |
 | hubDeviceId        | String     | device's parent Hub ID. *000000000000* when the device itself is a Hub or it is connected through Wi-Fi. |                          |
 
@@ -2207,8 +2207,7 @@ The `body` object contains the following properties,
 | Key             | Value Type | Description                                               |
 | --------------- | ---------- | --------------------------------------------------------- |
 | deviceId        | String     | device ID                                                 |
-| online    | Boolean     | the connection status of the device. *true* or *false* |
-| deviceType      | String     | device type. *LED Strip Light 3*                           |
+| deviceType      | String     | device type. *Strip Light 3*                           |
 | hubDeviceId        | String     | device's parent Hub ID                                       |
 | version         | String     | the current BLE and Wi-Fi firmware version, e.g. V3.1-6.3 |
 | power                  | String     | ON/OFF state                                                 |

--- a/README.md
+++ b/README.md
@@ -2474,10 +2474,9 @@ Send control commands to physical devices and virtual infrared remote devices.
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |
 | ---------------------------- | ----------- | ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | Relay Switch 2PM | command     | turnOn              | “1”or"2"                                                      | set to ON state 1 represents channel 1 2 represents channel 2                                             |
-| Relay Switch 2PM | command     | turnOff             | default                                                      | set to OFF state                                             |
+| Relay Switch 2PM | command     | turnOff             | “1”or"2"                                                      | set to OFF state 1 represents channel 1 2 represents channel 2                                            |
 | Relay Switch 2PM | command     | toggle              | “1”or"2"                                                    | toggle 1 represents channel 1 2 represents channel 2state                                                 |
-| Relay Switch 2PM | command | setMode | “1”/“2”，`0~3` | The first item represents the switching of channel number, 1 represents channel number 1 and 2 represents channel number 2. The second item represents set the switch mode. `0`, toggle mode; `1`, edge switch mode; `2`, detached switch mode; `3`, momentary switch mode |
-| Relay Switch 2PM | command | setPosition | `0~100` | Set roller blind opening and closing percentage. `0`, Open All; `100`, Close All  |
+| Relay Switch 2PM | command | setMode | channel;mode<br>e.g `1;0` | The first item represents the switching of channel number, 1 represents channel number 1 and 2 represents channel number 2. The second item represents set the switch mode. `0`, toggle mode; `1`, edge switch mode; `2`, detached switch mode; `3`, momentary switch mode |
 
 ##### Garage Door Opener
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |

--- a/README.md
+++ b/README.md
@@ -2175,6 +2175,9 @@ The `body` object contains the following properties,
 | switch2UsedElectricity | Integer    | switch2 daily power consumption, measured in watt-minutes         |
 | switch1ElectricCurrent | Integer    | the switch1 electrical current measured in mA                     |
 | switch2ElectricCurrent | Integer    | the switch2 electrical current measured in mA                     |
+| calibrate     | Boolean      | determines if the open and the closed positions have been properly calibrated or not |
+| position      | Integer     | the current position, 0-100                               |
+| isStuck       | String       | determine if the roller blind is stuck                               |
 | hubDeviceId     | String     | Hub ID, equivalent to device ID                           |
 
 
@@ -2476,6 +2479,7 @@ Send control commands to physical devices and virtual infrared remote devices.
 | Relay Switch 2PM | command     | turnOff             | “1”or"2"                                                      | set to OFF state 1 represents channel 1 2 represents channel 2                                            |
 | Relay Switch 2PM | command     | toggle              | “1”or"2"                                                    | toggle 1 represents channel 1 2 represents channel 2state                                                 |
 | Relay Switch 2PM | command | setMode | channel;mode<br>e.g `1;0` | The first item represents the switching of channel number, 1 represents channel number 1 and 2 represents channel number 2. The second item represents set the switch mode. `0`, toggle mode; `1`, edge switch mode; `2`, detached switch mode; `3`, momentary switch mode |
+| Relay Switch 2PM | command | setPosition | `0~100` | Set roller blind opening and closing percentage. `0`, Open All; `100`, Close All  |
 
 ##### Garage Door Opener
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |

--- a/README.md
+++ b/README.md
@@ -4548,8 +4548,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4578,8 +4577,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4608,8 +4606,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 
@@ -4638,8 +4635,7 @@ When an event gets triggered, SwitchBot server will send a `POST` request to the
 | deviceType   | String     | the type of the device                     |
 | deviceMac    | String     | the MAC address of the device |
 | power | String | the power state of the device |
-| mode | Integer | the current mode. `1`, level 4; `2`, level 3; `3`, level 2; `4`, level 1; `5`, humidity mode; `6`, sleep mode; `7`, auto mode; `8`, drying mode |
-| drying  | Boolean | determines if the device is drying its filter or not |
+| mode | Integer | the current mode. `1`, normal or fan mode; `2`, auto mode; `3`, sleep mode; `4`, pet mode |
 | childLock | Integer | child lock. `0`, disabled; `1`, enabled |
 | timeOfSample | Long       | the time stamp when the event is sent      |
 

--- a/README.md
+++ b/README.md
@@ -2140,9 +2140,9 @@ The `body` object contains the following properties,
 | deviceId        | String     | device ID                                                 |
 | deviceType      | String     | device type. *Relay Switch 1PM*                           |
 | switchStatus    | Integer    | the current switch state. `0`, off; `1`, on               |
-| voltage         | Integer    | the current voltage, measured in Volt                     |
+| voltage         | Float      | the current voltage, measured in Volt                     |
 | version         | String     | the current BLE and Wi-Fi firmware version, e.g. V3.1-6.3 |
-| power           | Integer    | the current power, measured in Watts                      |
+| power           | Float      | the current power, measured in Watts                      |
 | usedElectricity | Integer    | daily power consumption, measured in watt-minutes         |
 | electricCurrent | Integer    | the electrical current measured in mA                     |
 


### PR DESCRIPTION
This pull request includes corrections for multiple errors in the API documentation. 

### The corrections fall into the following three categories:
* Type1: Corrections of clear errors that have been confirmed by checking the actual device's API behavior.
   * (It is possible that the error lies not in the documentation, but that the API implementation is not functioning as intended.)
* Type2: Corrections of clear errors that can be inferred from the product's functionality or discrepancies in Webhook/Status.
* Type3: Corrections that seem appropriate due to suspected typographical errors, but need verification as the actual device is not available.

### Correction details

* [Type1 : `Get device status` response for Hub 3](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/f1a9f1ac8ef4f729d16578a2bf83ba7e6fdeeb20)
   * Change the field name of `online` to `onlineStatus`.

* [Type1 : `Get device status` response for Relay Switch 1PM](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/306c219413d35624e4ee05424ccfed3833cb03b8)
   * Change the data type of the `voltage` and `power` fields from integer to float.

* [Type1 : `Get device status` response for Relay Switch 2PM](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/0c19b942bd7fbfef9da54447d8ac3ee67d991561)
   * Change the data type of the `switch_Voltage` and `switch_Power` fields from integer to float.
   * Adjust the case sensitivity of the status fields to match the actual API specifications, e.g., `switch1usedElectricity` to `switch1UsedElectricity`.
   * ~~Remove field `calibrate`,`position`,`isStuck`~~ -> [re-add](https://github.com/OpenWonderLabs/SwitchBotAPI/pull/405/commits/5f7c2b1286837aca849fea20c797c336c81a1a7a)
      * These will work if you select Roller Blind Mode instead of Switch Mode when adding a device. (The deletion was a mistake.)

* [Type1 : `Get device status` response for Relay Switch 1,1PM,2PM](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/149d3f2281eb4964911fb8e3f1662e88c7b0590d)
   * Add the `hubDeviceId` field for each device.

* [Type1 : `Send device control commands` for Relay Switch 2PM](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/b497e18c98f50eabc43f796e1c5a6a400c605546)
   * Add argument(channnel) to the `turnOff` command
   * Change the argument transmission method for the `setMode` command from comma-separated to semicolon-separated
   ~~* Remove the `setPosition` command~~  -> [re-add](https://github.com/OpenWonderLabs/SwitchBotAPI/pull/405/commits/5f7c2b1286837aca849fea20c797c336c81a1a7a)
      * These will work if you select Roller Blind Mode instead of Switch Mode when adding a device. (The deletion was a mistake.)

* [Type1 : `Get device list` response for RGBWW Strip Light 3](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/eadd8dec9f66357c890f773938ada42a65e23236)
   * fix DeviceType `LED Strip Light3` -> `Strip Light3`

* [Type1 : `Get device status` response for RGBWW Strip Light 3](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/eadd8dec9f66357c890f773938ada42a65e23236)
   * fix DeviceType `LED Strip Light3` -> `Strip Light3`
    * remove `online` field

* [Type2 : `changeParam` command for K10+ Pro Combo](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/2feb1f07acdccde70f33e08ddeff04b06aef794a)
  * Remove the `waterLevel` property.
  It seems this was forgotten when copying from the S10 model.

* [Type2 : Webhook payload for Air Purifier 4 models](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/88f2118a15806adadf4415b57d4b6374796612fe)
  * Remove the `drying` property.
  * Modify the description of the `mode` property to match the Status API.
  These changes appear to have been overlooked when copying from the Evaporative Humidifier (Auto-refill) model.

* [Type3 : Webhook payload for K20+ Pro](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/0f80043bb3aee5d7d1949ee4df8b1f14582ad610)
  * mod `DeviceType`(estimated value)
  * Match the table with the example.
  * Remove waterBaseBattery from the example, as it appears to be an obvious mistake.

* [Type3 : Webhook payload for Keypad Vision](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/82aa172fb7c33af1246b8bdc1addf1b323240f81)
  * mod `DeviceType`(estimated value)

* [Type3 : `Get device status` response for Lock Ultra](https://github.com/OpenWonderLabs/SwitchBotAPI/commit/e464c6478a4408d4a58514f66f9c987a5ee402e7)
   * Add response table based on estimated values, as response table does not exist.
   
@Minsheng Could you review this pull request?