### PR TITLE
Fix typo in the commands for Lock Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2441,8 +2441,8 @@ Send control commands to physical devices and virtual infrared remote devices.
 ##### Lock Pro
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |
 | ---------------------------- | ----------- | ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Lock                         | command     | lock                | default                                                      | rotate to locked position                                    |
-| Lock                         | command     | unlock              | default                                                      | rotate to unlocked position                                  |
+| Lock Pro                     | command     | lock                | default                                                      | rotate to locked position                                    |
+| Lock Pro                     | command     | unlock              | default                                                      | rotate to unlocked position                                  |
 
 ##### Humidifier
 | deviceType                   | commandType | Command             | command parameter                                            | Description                                                  |


### PR DESCRIPTION
## :recycle: Current situation

The `deviceType` fields of command set for the "Lock Pro" device is "Lock". There is a section for "Lock" right before this section, whose `deviceType` fields are also "Lock".

## :bulb: Proposed solution

Change them to "Lock Pro".

## :gear: Release Notes

Fix the `deviceType` of command set for the "Lock Pro".

## :heavy_plus_sign: Additional Information

None.

### Testing

None.

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
